### PR TITLE
Stop requiring bootsnap, the gem is not included, so It just causes a load error.

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,3 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Remove the `require 'bootsnap/setup'` line, added in commit [2953566](https://github.com/learn-co-curriculum/rails-long-running-tasks-lab/commit/2953566f4e2dc2d84a270906635b2dcde1855562).
It causes a load error because the bootsnap gem is not included in this lab.